### PR TITLE
Fix: Slides static file not proxied correct in some instances

### DIFF
--- a/plugins/google-slides/src/index.ts
+++ b/plugins/google-slides/src/index.ts
@@ -543,7 +543,8 @@ function processHtml(html: string) {
     .replace(
       /https:\\\/\\\/([^.]+?)\.googleusercontent\.com/g,
       "/plugin/google-slides/staticProxy/$1",
-    );
+    )
+    .replace(/src="\//, 'src="https://docs.google.com/');
 }
 
 export type AppRouter = ReturnType<ReturnType<typeof getAppRouter>>;


### PR DESCRIPTION
Opening the document with different account seems to give different links. This one is like so

```
<script
    src="/_/presentations/_/js/k=presentations.viewer.en.byVPM3iiZnU.es5.O/am=AASDAQ/d=0/wt=0/rs=AB6fld0s1Z7zxQ2FFODVEFbgACaZ6zvsEw/m=core"
    id="base-js" nonce="dev"></script>
```

Which then resolves to our URL. So we just `docs.google.com` for now. Ideally we want to proxy it and save it. But at this stage, it doesn't really make a difference since we're not caching it yet