### PR TITLE
Fix: syntax fixes for windows

### DIFF
--- a/backend/db/.gmrc.js
+++ b/backend/db/.gmrc.js
@@ -68,7 +68,7 @@ module.exports = {
     "!afterReset.sql",
     {
       _: "command",
-      command: `node '${path.resolve(__dirname, "../worker/install-db-schema.js")}'`,
+      command: `node "${path.resolve(__dirname, "../worker/install-db-schema.js")}"`,
     },
   ],
 

--- a/backend/server/package.json
+++ b/backend/server/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs",
     "start": "sh ./scripts/process-public-next-env.sh && node -r @repo/config/env -r @repo/observability/initTracing dist/index.js",
-    "dev": "concurrently \"yarn build --watch\" \"nodemon --signal SIGINT --watch '../../**/dist/**/*.js' --ignore '../../e2e/**' -x 'node --inspect=9678 -r @repo/config/env -r @repo/observability/initTracing -r source-map-support/register' dist/index.js\"",
+    "dev": "concurrently \"yarn build --watch\" \"yarn dev:server\"",
+    "dev:server": "nodemon --signal SIGINT --watch '../../**/dist/**/*.js' --ignore '../../e2e/**' -x \"node --inspect=9678 -r @repo/config/env -r @repo/observability/initTracing -r source-map-support/register\" dist/index.js",
     "schema:export": "NODE_OPTIONS=\"-r @repo/config/env\" yarn ts-node scripts/schema-export.ts",
     "cloudflare:import": "(echo \"export const cloudflareIps: string[] = [\"; (curl -Ls https://www.cloudflare.com/ips-v4 | sort | sed -e \"s/^/  \\\"/\" -e \"s/$/\\\",/\"); echo \"];\") > src/cloudflare.ts",
     "test": "NODE_ENV=test NODE_OPTIONS=\"-r @repo/config/env\" yarn vitest"

--- a/backend/server/src/pluginManager.ts
+++ b/backend/server/src/pluginManager.ts
@@ -110,6 +110,7 @@ const _linkPlugin = async (pluginName: string) => {
       fs.symlinkSync(
         path.resolve(localPluginDir, pluginName),
         path.resolve(pluginsPath, pluginName),
+        process.platform === "win32" ? "junction" : "dir",
       );
     } else {
       logger.warn(`Linking local plugin '${pluginName}' failed`);

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -5425,6 +5425,9 @@ type ScreenByCodeResult {
 A condition to be used against `Screen` object types. All fields are tested for equality and combined with a logical ‘and.’
 """
 input ScreenCondition {
+  """Checks for equality with the object’s `code` field."""
+  code: String
+
   """Checks for equality with the object’s `currentProjectId` field."""
   currentProjectId: UUID
 
@@ -5633,6 +5636,9 @@ A filter to be used against `Screen` object types. All fields are combined with 
 input ScreenFilter {
   """Checks for all expressions in this list."""
   and: [ScreenFilter!]
+
+  """Filter by the object’s `code` field."""
+  code: StringFilter
 
   """Filter by the object’s `currentProjectId` field."""
   currentProjectId: UUIDFilter
@@ -6217,6 +6223,8 @@ type ScreensEdge {
 
 """Methods to use when ordering `Screen`."""
 enum ScreensOrderBy {
+  CODE_ASC
+  CODE_DESC
   CURRENT_PROJECT_ID_ASC
   CURRENT_PROJECT_ID_DESC
   ID_ASC

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "engines": {
     "node": ">=18"
   },
-  "packageManager": "yarn@4.4.0",
+  "packageManager": "yarn@4.16.0+sha512.5374c94eb4ef6aa8188fb112f20c1aa6569f248d676c5e576e1fd2a1a4d8d87a96df65d9dfe1c2a0252cbe38bda46cf18d955005b81b43cc7607a5c9d56fd2b6",
   "workspaces": [
     "apps/*",
     "backend/*",


### PR DESCRIPTION
Syntax fixes for windows so that windows terminals do not crash trying to read certain quotations and nested quotations. 

".gmrc.js" and "package.json" files were the fixes.

The other 3 files were automatically newly added code not typed myself.